### PR TITLE
The <logger> values with dash can't be parsed

### DIFF
--- a/src/Dubture/Monolog/Parser/LineLogParser.php
+++ b/src/Dubture/Monolog/Parser/LineLogParser.php
@@ -21,8 +21,8 @@ class LineLogParser implements LogParserInterface
      * @var string
      */
     protected $pattern = array(
-        'default' => '/\[(?P<date>.*)\] (?P<logger>\w+).(?P<level>\w+): (?P<message>[^\[\{]+) (?P<context>[\[\{].*[\]\}]) (?P<extra>[\[\{].*[\]\}])/',
-        'error'   => '/\[(?P<date>.*)\] (?P<logger>\w+).(?P<level>\w+): (?P<message>(.*)+) (?P<context>[^ ]+) (?P<extra>[^ ]+)/'
+        'default' => '/\[(?P<date>.*)\] (?P<logger>\([a-zA-Z\'-]+)).(?P<level>\w+): (?P<message>[^\[\{]+) (?P<context>[\[\{].*[\]\}]) (?P<extra>[\[\{].*[\]\}])/',
+        'error'   => '/\[(?P<date>.*)\] (?P<logger>\([a-zA-Z\'-]+)).(?P<level>\w+): (?P<message>(.*)+) (?P<context>[^ ]+) (?P<extra>[^ ]+)/'
     );
 
 


### PR DESCRIPTION
The `\w+` regex rule doesn't select words with dash.
If you use a kebab cased name in a \Monolog\Logger constructor (e.g : `new Logger('foo-bar');`), LineLogParser.php will return an empty array